### PR TITLE
test : Adds RedisTest.testRedisAddItemSetsExpires

### DIFF
--- a/test/Storage/Adapter/RedisTest.php
+++ b/test/Storage/Adapter/RedisTest.php
@@ -162,6 +162,32 @@ class RedisTest extends CommonAdapterTest
         }
     }
 
+    public function testRedisAddItemSetsExpires()
+    {
+        $capabilities = $this->_storage->getCapabilities();
+
+        if ($capabilities->getMinTtl() === 0) {
+            $this->markTestSkipped("Adapter doesn't support item expiration");
+        }
+
+        $ttl = $capabilities->getTtlPrecision();
+        $this->_options->setTtl($ttl);
+
+        $this->waitForFullSecond();
+
+        $this->assertTrue($this->_storage->addItem('key', 'value'));
+
+        // wait until the item expired
+        $wait = $ttl + $capabilities->getTtlPrecision();
+        usleep($wait * 2000000);
+
+        if (!$capabilities->getUseRequestTime()) {
+            $this->assertFalse($this->_storage->hasItem('key'));
+        } else {
+            $this->assertTrue($this->_storage->hasItem('key'));
+        }
+    }
+
     /* ResourceManager */
 
     public function testSocketConnection()


### PR DESCRIPTION
- Adds test for ensuring addItem adheres to TTL as expected. Test is a variation of the CommonAdapterTest.testHasItemReturnsFalseOnExpiredItem.
